### PR TITLE
Fixing merge frosillo-m_hw3_experiment 

### DIFF
--- a/BACtrack/app/build.gradle.kts
+++ b/BACtrack/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.bactrack"
-        minSdk = 24
+        minSdk = 31
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/BACtrack/app/src/main/AndroidManifest.xml
+++ b/BACtrack/app/src/main/AndroidManifest.xml
@@ -13,6 +13,11 @@
         android:theme="@style/Theme.BACtrack"
         tools:targetApi="31">
         <activity
+            android:name=".bacCalculation"
+            android:exported="false"
+            android:label="@string/title_activity_bac_calculation"
+            android:theme="@style/Theme.BACtrack" />
+        <activity
             android:name=".Landing"
             android:exported="false"
             android:label="@string/title_activity_landing"

--- a/BACtrack/app/src/main/java/com/example/bactrack/Landing.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/Landing.kt
@@ -1,6 +1,7 @@
 package com.example.bactrack
 
 import android.annotation.SuppressLint
+import com.example.bactrack.SessionManager.totalAlcMass
 import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -224,6 +225,11 @@ fun BottomNavigationBar(
 
 @Composable
 fun HomeScreen() {
+    // Values for testing.. this will be fixed after MVP!
+    val userWeight = 70.0 // Example weight in kg
+    val userSex = "male" // Example sex
+    val totalAlcoholConsumed = totalAlcMass
+    val timeSinceDrinking = 1.0 // Example: 2 hours since drinking started
     var counter by remember { mutableStateOf(0) }
     val maxCounter = 10 // Set a max level for the mug
     val fillLevel by animateFloatAsState(targetValue = (counter / maxCounter.toFloat()).coerceIn(0f, 1f))
@@ -280,11 +286,21 @@ fun HomeScreen() {
                 item {
                     Text(
                         modifier = Modifier.padding(top = 1.dp),
-                        text = "Your BAC is : " + SessionManager.totalDrinks.toString(),
+                        text = "Your drink count is : " + SessionManager.totalDrinks.toString(),
                         color = Color.Red,
                         fontWeight = FontWeight.Bold,
                         style = MaterialTheme.typography.bodyLarge,
-                        fontSize = 48.sp
+                        fontSize = 35.sp
+                    )
+                }
+                item {
+                    Text(
+                        //modifier = Modifier.padding(top = 100.dp),
+                        text = "Your BAC is : ${calculateBAC(totalAlcoholConsumed, userWeight, userSex, timeSinceDrinking).format(3)}",
+                        color = Color.Red,
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontSize = 30.sp
                     )
                 }
 
@@ -318,7 +334,7 @@ fun Mug(fillLevel: Float) {
         )
     }
 }
-
+fun Double.format(digits: Int) = "%.${digits}f".format(this)
 @Composable
 fun HistoryScreen() {
     Surface(

--- a/BACtrack/app/src/main/java/com/example/bactrack/bacCalculation.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/bacCalculation.kt
@@ -1,0 +1,26 @@
+package com.example.bactrack
+
+fun calculateBAC(totalAlcoholConsumed: Double, weight: Double, sex: String, time: Double): Double {
+    // Constants
+    val r = if (sex.equals("female", ignoreCase = true)) 0.55 else 0.68  // Alcohol distribution ratio
+    val beta = 0.015  // Alcohol elimination rate
+
+    // Convert weight from kg to grams
+    val weightInGrams = weight * 1000
+
+    // Calculate BAC
+    val bac = (totalAlcoholConsumed / (r * weightInGrams)) - (beta * time)
+
+    // Return BAC, ensuring it's not negative
+    return if (bac < 0) 0.0 else bac
+}
+
+
+data class User(
+    val name: String,
+    val weight: Double,
+    val sex: String, // "male" or "female"
+    val totalAlcoholConsumed: Double
+)
+
+

--- a/BACtrack/app/src/main/res/values/strings.xml
+++ b/BACtrack/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">BACtrack</string>
     <string name="title_activity_landing">Landing</string>
+    <string name="title_activity_bac_calculation">bacCalculation</string>
 </resources>


### PR DESCRIPTION
(This is copied from rosillo-m pull request)

In this PR, I added the BAC calculation and displayed it on the homepage after the drink count. As of now, the calculation uses default values for most of the BAC parameters (for testing purposes) but it will be changed to work with the user inputs.
Here is a picture of how it looks:

![Uploading image.png…]()

Closes https://github.com/ucsb-cs184-f24/team10AlcTracker/issues/30