### PR TITLE
BAC calculation Completed

### DIFF
--- a/BACtrack/app/src/main/java/com/example/bactrack/SessionManager.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/SessionManager.kt
@@ -6,14 +6,40 @@ import androidx.compose.runtime.setValue
 
 object SessionManager {
     var currentSession by mutableStateOf(CurrentSession())
+    var firstDrinkTime: Long? = null
 
-        //this value will dynamically update thanks to the get function
     val totalDrinks: Int
         get() = currentSession.numBeers + currentSession.numWine + currentSession.numShots + currentSession.numCocktails
 
-    //this will return total mass of alcohol consumed in grams
     val totalAlcMass: Double
-        get() = (currentSession.numBeers * 14.0) + (currentSession.numWine * 20.8) + (currentSession.numShots * 14) + (currentSession.numCocktails * 27.1)
-}
-//this is a global object that will be used to store the current session
+        get() = (currentSession.numBeers * 14.0) +
+                (currentSession.numWine * 20.8) +
+                (currentSession.numShots * 14.0) +
+                (currentSession.numCocktails * 27.1)
 
+    var bac by mutableStateOf(0.0)
+
+    fun addDrink(drinkType: String) {
+        currentSession = when (drinkType) {
+            "beer" -> currentSession.copy(numBeers = currentSession.numBeers + 1)
+            "wine" -> currentSession.copy(numWine = currentSession.numWine + 1)
+            "shot" -> currentSession.copy(numShots = currentSession.numShots + 1)
+            "cocktail" -> currentSession.copy(numCocktails = currentSession.numCocktails + 1)
+            else -> currentSession
+        }
+        if (firstDrinkTime == null) firstDrinkTime = System.currentTimeMillis()
+        recalculateBAC()
+    }
+
+    fun recalculateBAC() {
+        val elapsedTime = getElapsedTimeInHours()
+        val user = PersonManager.mainUser
+        bac = calculateBAC(totalAlcMass, user.weight, if (user.sex) "male" else "female", elapsedTime)
+    }
+
+    private fun getElapsedTimeInHours(): Double {
+        return if (firstDrinkTime != null) {
+            (System.currentTimeMillis() - firstDrinkTime!!) / 3600000.0
+        } else 0.0
+    }
+}

--- a/BACtrack/app/src/main/java/com/example/bactrack/bacCalculation.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/bacCalculation.kt
@@ -11,7 +11,7 @@ fun calculateBAC(totalAlcoholConsumed: Double, weight: Double, sex: String, time
     val beta = 0.015  // Alcohol elimination rate
 
     // Convert weight from kg to grams
-    val weightInGrams = weight * 1000 + currentSession.numBeers + mainUser.totalAlcoholConsumed
+    val weightInGrams = weight * 1000
 
     // Calculate BAC
     val bac = (totalAlcoholConsumed / (r * weightInGrams)) - (beta * time)

--- a/BACtrack/app/src/main/java/com/example/bactrack/uiElements/AlertDialog.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/uiElements/AlertDialog.kt
@@ -59,10 +59,7 @@ fun AlertDialog(
                     horizontalArrangement = Arrangement.Center
                 ) {
                     Button(
-                        onClick = {
-                            SessionManager.currentSession = SessionManager.currentSession.copy(numBeers =SessionManager.currentSession.numBeers + 1)
-                                //add logic to update BAC here
-                                  },
+                        onClick = { SessionManager.addDrink("beer") },
                         modifier = Modifier
                             .width(130.dp)
                             .padding(10.dp)
@@ -70,11 +67,9 @@ fun AlertDialog(
                         Icon(imageVector = Icons.Filled.SportsBar, contentDescription = "Beer Icon")
                         Text(text = "Beer")
                     }
+
                     Button(
-                        onClick = {
-                            SessionManager.currentSession = SessionManager.currentSession.copy(numWine =SessionManager.currentSession.numWine + 1)
-                                  //add logic to update BAC here
-                                  },
+                        onClick = { SessionManager.addDrink("wine") },
                         modifier = Modifier
                             .width(130.dp)
                             .padding(10.dp)
@@ -88,10 +83,7 @@ fun AlertDialog(
                     horizontalArrangement = Arrangement.Center
                 ) {
                     Button(
-                        onClick = {
-                            SessionManager.currentSession = SessionManager.currentSession.copy(numShots =SessionManager.currentSession.numShots + 1)
-                                  //add logic to update BAC here
-                                  },
+                        onClick = { SessionManager.addDrink("shot") },
                         modifier = Modifier
                             .width(130.dp)
                             .padding(10.dp)
@@ -99,23 +91,17 @@ fun AlertDialog(
                         Icon(imageVector = Icons.Filled.LocalDrink, contentDescription = "Shot Icon")
                         Text(text = "Shot")
                     }
+
                     Button(
-                        onClick = {
-                            SessionManager.currentSession = SessionManager.currentSession.copy(numCocktails =SessionManager.currentSession.numCocktails + 1)
-                            //add logic to update BAC here
-                        },
+                        onClick = { SessionManager.addDrink("cocktail") },
                         modifier = Modifier
                             .width(130.dp)
                             .padding(10.dp)
                     ) {
                         Icon(imageVector = Icons.Filled.LocalBar, contentDescription = "Cocktail Icon")
-                        Text(text = "Cktl")
-
+                        Text(text = "Cocktail")
                     }
                 }
-
-
-
             }
         }
     )


### PR DESCRIPTION
This PR adds the correct BAC calculation that takes as parameters the correct time that starts when the user inputs the first drink as well as the user's input for the weight and sex. The BAC calculation also updates automatically every minute.

In addition, this PR also adds a pop-up window for adding drinks (beer, wine, cocktail, shot).

Here is a picture of how it looks now:

- Pop-up window:

<img width="392" alt="Screenshot 2024-11-15 at 1 33 30 PM" src="https://github.com/user-attachments/assets/ec7748a1-6fb6-4339-9eb6-caf7ad343fb3">

- BAC periodic calculation (it updates on its own every minute)

<img width="392" alt="Screenshot 2024-11-15 at 1 33 11 PM" src="https://github.com/user-attachments/assets/86712c0c-3eb7-4943-8fe1-c0c61aae6ed3">

<img width="392" alt="Screenshot 2024-11-15 at 1 34 40 PM" src="https://github.com/user-attachments/assets/e420a86c-c448-4406-9c6e-16d5ec200eb0">

