### PR TITLE
Adding Notifcation to add beer and shot wihtout opening

### DIFF
--- a/BACtrack/app/src/main/AndroidManifest.xml
+++ b/BACtrack/app/src/main/AndroidManifest.xml
@@ -2,7 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+
     <application
+
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -12,20 +18,28 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.BACtrack"
         tools:targetApi="31">
+
+        <receiver android:name=".DrinkActionReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ADD_SHOT" />
+                <action android:name="ADD_BEER" />
+                <action android:name="ADD_OTHER" />
+            </intent-filter>
+        </receiver>
         <activity
             android:name=".bacCalculation"
             android:exported="false"
             android:label="@string/title_activity_bac_calculation"
             android:theme="@style/Theme.BACtrack"
-            android:windowSoftInputMode="adjustResize"/>
-
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".Landing"
             android:exported="false"
             android:label="@string/title_activity_landing"
             android:theme="@style/Theme.BACtrack"
-            android:windowSoftInputMode="adjustResize"/>
-
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -38,6 +52,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".NotificationService"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/BACtrack/app/src/main/java/com/example/bactrack/Landing.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/Landing.kt
@@ -1,6 +1,7 @@
 package com.example.bactrack
 import com.example.bactrack.SessionManager.totalAlcMass
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -230,6 +231,9 @@ import kotlin.random.Random
 class Landing : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+
+        val intent = Intent(this, NotificationService::class.java)
+        startService(intent)
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
@@ -997,13 +1001,12 @@ fun PersonalInformationSection() {
     val formattedDob = remember(dob) { formatDate(dob) }
 
     val focusManager = LocalFocusManager.current
-
     Surface(
         modifier = Modifier.fillMaxSize()
             .clickable(
                 onClick = { focusManager.clearFocus() },
                 indication = null, //removes ripple effect
-                interactionSource = MutableInteractionSource()
+                interactionSource = remember { MutableInteractionSource() }
             ),
         color = Color(0xFFADD8E6)
     ) {

--- a/BACtrack/app/src/main/java/com/example/bactrack/NotifcationReciever.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/NotifcationReciever.kt
@@ -1,0 +1,35 @@
+package com.example.bactrack
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+
+class DrinkActionReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == "ADD_SHOT") {
+            // Handle the action here
+            Log.d("DrinkActionReceiver", "Add Drink button pressed.")
+
+            // You can add logic to add a drink, update UI, or start an activity
+            // Example: Start LandingActivity or any action you need
+            val landingIntent = Intent(context, Landing::class.java)
+            landingIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            SessionManager.addDrink("shot")
+            Toast.makeText(context, "Drink added", Toast.LENGTH_SHORT).show()
+
+        }
+        else if (intent.action == "ADD_BEER"){
+            Log.d("DrinkActionReceiver", "Add Drink button pressed.")
+
+            // You can add logic to add a drink, update UI, or start an activity
+            // Example: Start LandingActivity or any action you need
+            val landingIntent = Intent(context, Landing::class.java)
+            landingIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            SessionManager.addDrink("beer")
+            Toast.makeText(context, "Drink added", Toast.LENGTH_SHORT).show()
+        }
+
+    }
+}

--- a/BACtrack/app/src/main/java/com/example/bactrack/Notification.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/Notification.kt
@@ -1,0 +1,89 @@
+package com.example.bactrack
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+
+class NotificationService : Service() {
+
+    private val CHANNEL_ID = "bac_track_channel"
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        showNotification()
+    }
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        showNotification()  // Show notification when service starts
+        return START_STICKY
+    }
+
+    // Create Notification Channel (required for Android 8.0 and above)
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "BACtrack Notifications"
+            val descriptionText = "Channel for BACtrack drink tracking"
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+            val notificationManager: NotificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    // Create and show the notification
+    private fun showNotification() {
+        // Intent for the action button (PendingIntent)
+        val addShot = Intent(applicationContext, DrinkActionReceiver::class.java).apply {
+            action = "ADD_SHOT"
+        }
+
+        val pendingShotIntent: PendingIntent = PendingIntent.getBroadcast(
+            applicationContext,
+            0,
+            addShot,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val addBeer = Intent(applicationContext, DrinkActionReceiver::class.java).apply {
+            action = "ADD_BEER"
+        }
+        val pendingBeerIntent: PendingIntent = PendingIntent.getBroadcast(
+            applicationContext,
+            1,
+            addShot,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+
+
+        // Create the notification
+        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.bactrack_logo_better)  // Your app icon
+            .setContentTitle("BACtrack")
+            .setContentText("Track your drinks!")
+            .addAction(R.drawable.bactrack_logo_better, "Add Shot", pendingShotIntent)
+            .addAction(R.drawable.bactrack_logo_better, "Add Beer", pendingBeerIntent)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setOngoing(true)  // Keeps the notification visible
+            .build()
+
+        // Show the notification
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(1, notification)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+}

--- a/BACtrack/app/src/main/res/values/strings.xml
+++ b/BACtrack/app/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="app_name">BACtrack</string>
     <string name="title_activity_landing">Landing</string>
     <string name="title_activity_bac_calculation">bacCalculation</string>
+    <string name="title_activity_notification">Notification</string>
+    <string name="title_activity_notifcation_reciever">NotifcationReciever</string>
 </resources>


### PR DESCRIPTION
Start of allowing people to add drinks without opening the app up. "ADD other" currently only redirects if the app is already open.