### PR TITLE
History list Additions to track past alc consumption

### DIFF
--- a/BACtrack/app/src/main/java/com/example/bactrack/Landing.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/Landing.kt
@@ -933,7 +933,7 @@ fun HistoryItem(session: BACSession) {
                 color = Color.White.copy(alpha = 1f) // Semi-transparent text
             )
             Text(
-                text = "Duration: ${session.startTime-session.endTime} minutes",
+                text = "Duration: ${formatTimestamp(session.endTime-session.startTime)} minutes",
                 style = MaterialTheme.typography.bodyLarge,
                 color = Color.White.copy(alpha = 1f) // Semi-transparent text
             )

--- a/BACtrack/app/src/main/java/com/example/bactrack/SessionManager.kt
+++ b/BACtrack/app/src/main/java/com/example/bactrack/SessionManager.kt
@@ -1,13 +1,15 @@
 package com.example.bactrack
 
+import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.setValue
 
 object SessionManager {
     var currentSession by mutableStateOf(CurrentSession())
     var firstDrinkTime: Long? = null
-
+    val historyList = mutableStateListOf<BACSession>()
     val totalDrinks: Int
         get() = currentSession.numBeers + currentSession.numWine + currentSession.numShots + currentSession.numCocktails
 
@@ -18,7 +20,8 @@ object SessionManager {
                 (currentSession.numCocktails * 27.1)
 
     var bac by mutableStateOf(0.0)
-
+    var peakBac by mutableStateOf(0.0)
+    var start by mutableStateOf(false)
     fun addDrink(drinkType: String) {
         currentSession = when (drinkType) {
             "beer" -> currentSession.copy(numBeers = currentSession.numBeers + 1)
@@ -35,6 +38,27 @@ object SessionManager {
         val elapsedTime = getElapsedTimeInHours()
         val user = PersonManager.mainUser
         bac = calculateBAC(totalAlcMass, user.weight, if (user.sex) "male" else "female", elapsedTime)
+        if (bac > peakBac) {
+            peakBac = bac
+        }
+
+        Log.d("BAC", "$bac")
+        Log.d("TIMEGOING", "$elapsedTime")
+        if (bac < 0.0001 && firstDrinkTime != null) {  // this is my best use right now, will cause issues if bac >= 0.001 because the initial bac is less than that after 1 shot.
+            // Save session to history
+            val session = BACSession(
+                startTime = firstDrinkTime!!,
+                endTime = System.currentTimeMillis(),
+                peakBAC = peakBac,
+                duration = System.currentTimeMillis() - firstDrinkTime!!
+            )
+            historyList.add(session)
+
+
+            peakBac = 0.0
+            firstDrinkTime = null
+            currentSession = CurrentSession()
+        }
     }
 
     private fun getElapsedTimeInHours(): Double {


### PR DESCRIPTION
Finished history additions. It will start when first drink is taken in and session will end when bac < 0.0001. Will make better check in the future.

It also saves peak BAC. 

Ignore the negative number, I had end and start flipped.

![IMG_1383](https://github.com/user-attachments/assets/a344d202-3389-47e8-8abb-18078a21cb9a)
